### PR TITLE
Made changes to return null when INFO is not requested.

### DIFF
--- a/Senzing.Sdk.Tests/core/SzCoreEngineWriteTest.cs
+++ b/Senzing.Sdk.Tests/core/SzCoreEngineWriteTest.cs
@@ -736,7 +736,7 @@ internal class SzCoreEngineWriteTest : AbstractTest
                 }
                 else
                 {
-                    Assert.That(result, Is.EqualTo(SzCoreEngine.NoInfo),
+                    Assert.That(result, Is.Null,
                                 "No INFO requested, but non-empty response received: "
                                 + testData);
                 }
@@ -908,7 +908,7 @@ internal class SzCoreEngineWriteTest : AbstractTest
                 }
                 else
                 {
-                    Assert.That(result, Is.EqualTo(SzCoreEngine.NoInfo),
+                    Assert.That(result, Is.Null,
                                 "No INFO requested, but non-empty response received");
                 }
 
@@ -1038,17 +1038,13 @@ internal class SzCoreEngineWriteTest : AbstractTest
 
                     if (dict.Count > 0)
                     {
-                        Assert.IsTrue(dict.ContainsKey("DATA_SOURCE"),
-                                      "Info message lacking DATA_SOURCE key: " + testData);
-                        Assert.IsTrue(dict.ContainsKey("RECORD_ID"),
-                                      "Info message lacking RECORD_ID key: " + testData);
                         Assert.IsTrue(dict.ContainsKey("AFFECTED_ENTITIES"),
                                       "Info message lacking AFFECTED_ENTITIES key: " + testData);
                     }
                 }
                 else
                 {
-                    Assert.That(result, Is.EqualTo(SzCoreEngine.NoInfo),
+                    Assert.That(result, Is.Null,
                                  "No INFO requested, but non-empty response received: "
                                  + testData);
                 }
@@ -1178,7 +1174,7 @@ internal class SzCoreEngineWriteTest : AbstractTest
                 }
                 else
                 {
-                    Assert.That(result, Is.EqualTo(SzCoreEngine.NoInfo),
+                    Assert.That(result, Is.Null,
                                  "No INFO requested, but non-empty response received: "
                                  + testData);
                 }
@@ -1348,7 +1344,7 @@ internal class SzCoreEngineWriteTest : AbstractTest
                     }
                     else
                     {
-                        Assert.That(result, Is.EqualTo(SzCoreEngine.NoInfo),
+                        Assert.That(result, Is.Null,
                                     "No INFO requested, but non-empty response received: "
                                     + result);
                     }

--- a/Senzing.Sdk/SzEngine.cs
+++ b/Senzing.Sdk/SzEngine.cs
@@ -84,7 +84,8 @@ namespace Senzing.Sdk
         ///
         /// <returns>
         /// The JSON <c>string</c> result produced by adding the record to the
-        /// repository (depending on the specified flags).
+        /// repository, or <c>null</c> if the specified flags do not indicate 
+        /// that an INFO message should be returned.
         /// </returns>
         ///
         /// <exception cref="SzUnknownDataSourceException">
@@ -186,8 +187,9 @@ namespace Senzing.Sdk
         /// </param>
         ///
         /// <returns>
-        /// The JSON <c>string</c> result produced by deleting the record from the
-        /// repository (depending on the specified flags).
+        /// The JSON <c>string</c> result produced by deleting the record from
+        /// the repository, or <c>null</c> if the specified flags do not
+        /// indicate that an INFO message should be returned.
         /// </returns>
         ///
         /// <exception cref="SzUnknownDataSourceException">
@@ -244,8 +246,9 @@ namespace Senzing.Sdk
         /// </param>
         ///
         /// <returns>
-        /// The JSON <c>string</c> result produced by reevaluating the record in the
-        /// repository (depending on the specified flags).
+        /// The JSON <c>string</c> result produced by reevaluating the record,
+        /// or <c>null</c> if the specified flags do not indicate that an INFO
+        /// message should be returned.
         /// </returns>
         ///
         /// <exception cref="SzUnknownDataSourceException">
@@ -295,8 +298,9 @@ namespace Senzing.Sdk
         /// </param>
         ///
         /// <returns>
-        /// The JSON <c>string</c> result produced by reevaluating the entity in
-        /// the repository (depending on the specified flags).
+        /// The JSON <c>string</c> result produced by reevaluating the entity,
+        /// or <c>null</c> if the specified flags do not indicate that an INFO
+        /// message should be returned.
         /// </returns>
         ///
         /// <exception cref="SzException">If a failure occurs.</exception>
@@ -1419,8 +1423,9 @@ namespace Senzing.Sdk
         /// </param>
         ///
         /// <returns>
-        /// The JSON <c>string</c> result produced by adding the record to the
-        /// repository (depending on the specified flags).
+        /// The JSON <c>string</c> result produced by processing the redo record,
+        /// or <c>null</c> if the specified flags do not indicate that an INFO
+        /// message should be returned.
         /// </returns>
         ///
         /// <exception cref="SzException">If a failure occurs.</exception>

--- a/Senzing.Sdk/core/SzCoreEngine.cs
+++ b/Senzing.Sdk/core/SzCoreEngine.cs
@@ -22,7 +22,8 @@ namespace Senzing.Sdk.Core
         /// The empty response for operations where the info can optionally
         /// generated but was not requested.
         /// </summary>
-        internal const string NoInfo = "{}";
+        internal const string NoInfo
+            = "{\"AFFECTED_ENTITIES\":[],\"INTERESTING_ENTITIES\":{\"ENTITIES\":[]}}";
 
         /// <summary>
         /// THe <see cref="SzCoreEnvironment"/> that constructed this instance.
@@ -152,7 +153,7 @@ namespace Senzing.Sdk.Core
                 long downstreamFlags = FlagsToLong(flags) & SdkFlagMask;
 
                 long returnCode = 0;
-                string result = NoInfo;
+                string result = null;
                 // check if we have flags to pass downstream or need info
                 if (downstreamFlags == 0L
                     && (flags == null || ((flags & SzWithInfo) == SzNoFlags)))
@@ -282,7 +283,7 @@ namespace Senzing.Sdk.Core
                 long downstreamFlags = FlagsToLong(flags) & SdkFlagMask;
 
                 long returnCode = 0;
-                string result = NoInfo;
+                string result = null;
                 // check if we have flags to pass downstream or need info
                 if (downstreamFlags == 0L
                     && (flags == null || ((flags & SzWithInfo) == SzNoFlags)))
@@ -1076,7 +1077,7 @@ namespace Senzing.Sdk.Core
             return this.env.Execute(() =>
             {
                 long returnCode = 0;
-                string result = NoInfo;
+                string result = null;
                 // check if we have flags to pass downstream
                 if (flags == null || ((flags & SzWithInfo) == SzNoFlags))
                 {
@@ -1117,7 +1118,7 @@ namespace Senzing.Sdk.Core
                 long downstreamFlags = FlagsToLong(flags) & SdkFlagMask;
 
                 long returnCode = 0;
-                string result = NoInfo;
+                string result = null;
 
                 // check if we have flags to pass downstream or need info
                 if (flags == null || ((flags & SzWithInfo) == SzNoFlags))
@@ -1170,7 +1171,7 @@ namespace Senzing.Sdk.Core
                 long downstreamFlags = FlagsToLong(flags) & SdkFlagMask;
 
                 long returnCode = 0;
-                string result = NoInfo;
+                string result = null;
 
                 // check if we have flags to pass downstream or need info
                 if (flags == null || ((flags & SzWithInfo) == SzNoFlags))
@@ -1197,7 +1198,7 @@ namespace Senzing.Sdk.Core
                     // check if record not found yields empty INFO
                     if (result.Length == 0)
                     {
-                        result = NoInfo;
+                        result = null;
                     }
                 }
 


### PR DESCRIPTION
Made changes to return null when INFO is not requested. 

ALSO: Patched reevaluateEntity() return place-holder NoInfo when INFO requested, but entity ID not found

Resolves Issue #53 