### PR TITLE
Updated InstallLocations.cs to use [install]/etc as a potential config directory

### DIFF
--- a/Senzing.Sdk.Tests/nativeszapi/InstallLocations.cs
+++ b/Senzing.Sdk.Tests/nativeszapi/InstallLocations.cs
@@ -477,7 +477,17 @@ public class InstallLocations
         if (configDir == null && defaultConfigPath != null)
         {
             configDir = new DirectoryInfo(defaultConfigPath);
-            if (!configDir.Exists) configDir = null;
+            if (!configDir.Exists) {
+                configDir = null;
+            }
+        }
+
+        // if still null, try to use the install's etc directory
+        if (configDir == null && installDir != null) {
+            configDir = new DirectoryInfo(Path.Combine(installDir.FullName, "etc"));
+            if (!configDir.Exists) {
+                configDir = null;
+            }                
         }
 
         if (configPath != null && configDir != null && !configDir.Exists)

--- a/Senzing.Sdk.Tests/nativeszapi/InstallLocations.cs
+++ b/Senzing.Sdk.Tests/nativeszapi/InstallLocations.cs
@@ -477,17 +477,20 @@ public class InstallLocations
         if (configDir == null && defaultConfigPath != null)
         {
             configDir = new DirectoryInfo(defaultConfigPath);
-            if (!configDir.Exists) {
+            if (!configDir.Exists)
+            {
                 configDir = null;
             }
         }
 
         // if still null, try to use the install's etc directory
-        if (configDir == null && installDir != null) {
+        if (configDir == null && installDir != null)
+        {
             configDir = new DirectoryInfo(Path.Combine(installDir.FullName, "etc"));
-            if (!configDir.Exists) {
+            if (!configDir.Exists)
+            {
                 configDir = null;
-            }                
+            }
         }
 
         if (configPath != null && configDir != null && !configDir.Exists)


### PR DESCRIPTION
Resolves Issue #59

Make the C# code match the Java test functionality to leverage the installation `etc` directory as a potential "config directory" when no other suitable directory can be determined.
