### PR TITLE
Removed hard-coded NoInfo return from reevaluateEntity() when INFO is empty-string and entity not found.

### DIFF
--- a/Senzing.Sdk/core/SzCoreEngine.cs
+++ b/Senzing.Sdk/core/SzCoreEngine.cs
@@ -19,13 +19,6 @@ namespace Senzing.Sdk.Core
         private const long SdkFlagMask = ~((long)SzWithInfo);
 
         /// <summary>
-        /// The empty response for operations where the info can optionally
-        /// generated but was not requested.
-        /// </summary>
-        internal const string NoInfo
-            = "{\"AFFECTED_ENTITIES\":[],\"INTERESTING_ENTITIES\":{\"ENTITIES\":[]}}";
-
-        /// <summary>
         /// THe <see cref="SzCoreEnvironment"/> that constructed this instance.
         /// </summary>
         private readonly SzCoreEnvironment env;
@@ -1136,12 +1129,6 @@ namespace Senzing.Sdk.Core
 
                     // set the info result if requested
                     result = info;
-
-                    // check if record not found yields empty INFO
-                    if (result.Length == 0)
-                    {
-                        result = NoInfo;
-                    }
                 }
 
                 // check the return code


### PR DESCRIPTION
Now that GDEV-3969 has been resolved to modify `Sz_reevaluateEntityWithInfo()` to return info indicating no affected entities when an entity is not found, we no longer need to have a hard-coded return value for the INFO to allow the unit tests to pass.

`SzCoreEngine.cs` has been modified to remove the check for an empty-string INFO and hard-coded replacement with the `NoInfo` constant.

Resolves Issue #63 