### PR TITLE
Update README.md for path to NuGet file

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ matches the native library version.
     - Example (macOS / Linux):
 
         ```console
-        dotnet nuget push /opt/senzing/er/lib/Senzing.Sdk.4.0.0-beta.2.0.nupkg --source dev
+        dotnet nuget push /opt/senzing/er/sdk/dotnet/Senzing.Sdk.4.0.0-beta.2.0.nupkg --source dev
         ```
 
     - Example (Windows):
 
         ```console
-        dotnet nuget push %USERPROFILE%\Senzing\er\lib\Senzing.Sdk.4.0.0-beta.2.0.nupkg --source dev
+        dotnet nuget push %USERPROFILE%\Senzing\er\sdk\dotnet\Senzing.Sdk.4.0.0-beta.2.0.nupkg --source dev
         ```
 
 1. Add the `Senzing.Sdk` NuGet package as a dependency to your project:


### PR DESCRIPTION
The NuGet file is moving from the `er/lib` sub-directory of the installation to the `er/sdk/dotnet` directory.  The `README.md` example of "pushing" the NuGet file now reflects that.
