### PR TITLE
#106: Updated applicability of SzEntityIncludeRecordFeatures flag

### DIFF
--- a/Senzing.Sdk/SzFlag.cs
+++ b/Senzing.Sdk/SzFlag.cs
@@ -485,6 +485,8 @@ namespace Senzing.Sdk
         /// This flag belongs to the following usage groups:
         /// <list>
         ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzPreprocessRecordFlags"/></description>
+        ///      <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
@@ -498,7 +500,7 @@ namespace Senzing.Sdk
         /// </list>
         /// </remarks>
         /// <seealso href="https://docs.senzing.com/flags/index.html"/>
-        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
+        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzPreprocessSet)]
         SzEntityIncludeRecordFeatures = (1L << 18),
 
         /// <summary>

--- a/Senzing.Sdk/SzFlagUsageGroup.cs
+++ b/Senzing.Sdk/SzFlagUsageGroup.cs
@@ -173,6 +173,9 @@ namespace Senzing.Sdk
         ///     <description><see cref="SzFlag.SzEntityIncludeInternalFeatures"/></description>
         ///   </item>
         ///   <item>
+        ///     <description><see cref="SzFlag.SzEntityIncludeRecordFeatures"/></description>
+        ///   </item>
+        ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludeRecordFeatureDetails"/></description>
         ///   </item>
         ///   <item>
@@ -215,6 +218,9 @@ namespace Senzing.Sdk
         /// <list>
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludeInternalFeatures"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="SzFlag.SzEntityIncludeRecordFeatures"/></description>
         ///   </item>
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludeRecordFeatureDetails"/></description>

--- a/Senzing.Sdk/SzFlags.cs
+++ b/Senzing.Sdk/SzFlags.cs
@@ -213,6 +213,7 @@ namespace Senzing.Sdk
         /// <seealso cref="SzFlagUsageGroup.SzRecordFlags"/>
         public const SzFlag SzRecordAllFlags
             = SzFlag.SzEntityIncludeInternalFeatures
+                | SzFlag.SzEntityIncludeRecordFeatures
                 | SzFlag.SzEntityIncludeRecordFeatureDetails
                 | SzFlag.SzEntityIncludeRecordFeatureStats
                 | SzFlag.SzEntityIncludeRecordDates
@@ -228,6 +229,7 @@ namespace Senzing.Sdk
         /// <seealso cref="SzFlagUsageGroup.SzPreprocessRecordFlags"/>
         public const SzFlag SzPreprocessRecordAllFlags
             = SzFlag.SzEntityIncludeInternalFeatures
+                | SzFlag.SzEntityIncludeRecordFeatures
                 | SzFlag.SzEntityIncludeRecordFeatureDetails
                 | SzFlag.SzEntityIncludeRecordFeatureStats
                 | SzFlag.SzEntityIncludeRecordJsonData


### PR DESCRIPTION
Resolves Issue #106 

Changed `SzFlag.cs` and `SzFlagUsageGroup.cs` to reflect that `SzEntityIncludeRecordFeatures` is applicable to `GetRecord()` and `PreprocessRecord()` as well as `GetEntity()` and other functions returning entity payloads.