### PR TITLE
Renamed `getConfigs()` to `getConfigRegistry()` in `SzConfigManager` (including implementations and examples)

### DIFF
--- a/Senzing.Sdk.Demo/demo/SzConfigManagerDemo.cs
+++ b/Senzing.Sdk.Demo/demo/SzConfigManagerDemo.cs
@@ -299,11 +299,11 @@ internal class SzConfigManagerDemo : AbstractTest
     }
 
     [Test]
-    public void GetConfigsDemo()
+    public void GetConfigRegistryDemo()
     {
         try
         {
-            // @start GetConfigs
+            // @start GetConfigRegistry
             // How to get a JSON document describing all registered configs
             try
             {
@@ -314,10 +314,10 @@ internal class SzConfigManagerDemo : AbstractTest
                 SzConfigManager configMgr = env.GetConfigManager();
 
                 // get the config definition for the config ID
-                string configsJson = configMgr.GetConfigs();
+                string configRegistry = configMgr.GetConfigRegistry();
 
                 // do something with the returned JSON (e.g.: parse it and extract values)
-                JsonObject? jsonObj = JsonNode.Parse(configsJson)?.AsObject();
+                JsonObject? jsonObj = JsonNode.Parse(configRegistry)?.AsObject();
 
                 JsonArray? jsonArr = jsonObj?["CONFIGS"]?.AsArray();
 

--- a/Senzing.Sdk.Tests/core/SzCoreConfigManagerTest.cs
+++ b/Senzing.Sdk.Tests/core/SzCoreConfigManagerTest.cs
@@ -387,7 +387,7 @@ internal class SzCoreConfigManagerTest : AbstractTest
             {
                 SzConfigManager configMgr = this.Env.GetConfigManager();
 
-                string result = configMgr.GetConfigs();
+                string result = configMgr.GetConfigRegistry();
 
                 JsonObject jsonObj = ParseJsonObject(result);
 

--- a/Senzing.Sdk/SzConfigManager.cs
+++ b/Senzing.Sdk/SzConfigManager.cs
@@ -207,7 +207,7 @@ namespace Senzing.Sdk
         ///
         /// <example>
         /// Usage:
-        /// <include file="../target/examples/SzConfigManagerDemo_GetConfigs.xml" path="/*"/>
+        /// <include file="../target/examples/SzConfigManagerDemo_GetConfigRegistry.xml" path="/*"/>
         /// </example>
         ///
         /// <returns>
@@ -219,7 +219,7 @@ namespace Senzing.Sdk
         /// <exception cref="Senzing.Sdk.SzException">
         /// If a failure occurs.
         /// </exception>
-        string GetConfigs();
+        string GetConfigRegistry();
 
         /// <summary>
         /// Gets the configuration ID of the default configuration for the

--- a/Senzing.Sdk/core/SzCoreConfigManager.cs
+++ b/Senzing.Sdk/core/SzCoreConfigManager.cs
@@ -456,7 +456,7 @@ namespace Senzing.Sdk.Core
         /// <c>SzConfigMgr_getConfigList_helper"</c> via
         /// <see cref="NativeConfigManager.GetConfigList(out string)"/>. 
         /// </summary>
-        public string GetConfigs()
+        public string GetConfigRegistry()
         {
             return this.env.Execute(() =>
             {

--- a/sz-sdk-csharp.sln
+++ b/sz-sdk-csharp.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Senzing.Sdk", "Senzing.Sdk\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Senzing.Sdk.Tests", "Senzing.Sdk.Tests\Senzing.Sdk.Tests.csproj", "{632DD128-6953-4143-A94E-34A3B43FBCE4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Senzing.Sdk.Demo", "Senzing.Sdk.Demo\Senzing.Sdk.Demo.csproj", "{8D11CAB4-AC3C-4D81-BE49-D1A7F3A18095}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{632DD128-6953-4143-A94E-34A3B43FBCE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{632DD128-6953-4143-A94E-34A3B43FBCE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{632DD128-6953-4143-A94E-34A3B43FBCE4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D11CAB4-AC3C-4D81-BE49-D1A7F3A18095}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D11CAB4-AC3C-4D81-BE49-D1A7F3A18095}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D11CAB4-AC3C-4D81-BE49-D1A7F3A18095}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D11CAB4-AC3C-4D81-BE49-D1A7F3A18095}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Resolves Issue #115 

Renamed `getConfigs()` to `getConfigRegistry()` in `SzConfigManager` (including implementations and examples)