### PR TITLE
#127: Refactored reusable core functions to SzCoreUtilities class

### DIFF
--- a/Senzing.Sdk.Tests/core/SzCoreConfigManagerTest.cs
+++ b/Senzing.Sdk.Tests/core/SzCoreConfigManagerTest.cs
@@ -8,6 +8,8 @@ using NUnit.Framework;
 
 using Senzing.Sdk.Core;
 
+using static Senzing.Sdk.Core.SzCoreUtilities;
+
 [TestFixture]
 [FixtureLifeCycle(LifeCycle.SingleInstance)]
 internal class SzCoreConfigManagerTest : AbstractTest
@@ -861,10 +863,7 @@ internal class SzCoreConfigManagerTest : AbstractTest
         {
             try
             {
-                SzCoreConfigManager configMgr
-                    = (SzCoreConfigManager)this.Env.GetConfigManager();
-
-                String comment = configMgr.CreateConfigComment(configDefinition);
+                String comment = CreateConfigComment(configDefinition);
 
                 Assert.That(comment, Is.EqualTo(expected),
                             "Comment not as expected: " + configDefinition);

--- a/Senzing.Sdk.Tests/core/SzCoreEnvironmentTest.cs
+++ b/Senzing.Sdk.Tests/core/SzCoreEnvironmentTest.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 
 using Senzing.Sdk.Core;
 
-using static Senzing.Sdk.Core.SzCoreEnvironment;
+using static Senzing.Sdk.Core.SzCoreUtilities;
 using static Senzing.Sdk.Tests.Util.TextUtilities;
 
 [TestFixture]
@@ -1200,7 +1200,7 @@ internal class SzCoreEnvironmentTest : AbstractTest
         this.PerformTest(() =>
         {
 
-            SzException e = SzCoreEnvironment.CreateSzException(errorCode, errorMessage);
+            SzException e = CreateSzException(errorCode, errorMessage);
 
             Assert.IsInstanceOf(exceptionType, e,
                                 "Type of exception is not as expected");

--- a/Senzing.Sdk/Senzing.Sdk.csproj
+++ b/Senzing.Sdk/Senzing.Sdk.csproj
@@ -9,7 +9,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <PackageVersion>4.0.0-beta.4.0</PackageVersion>
+    <PackageVersion>4.0.0-beta.4.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Senzing.Sdk/SzFlag.cs
+++ b/Senzing.Sdk/SzFlag.cs
@@ -20,7 +20,7 @@ namespace Senzing.Sdk
     /// </para>
     /// </remarks>
     /// 
-    /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+    /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
     [Flags]
     public enum SzFlag : long
     {
@@ -28,10 +28,9 @@ namespace Senzing.Sdk
         /// The bitwise flag that indicates that the Senzing engine should produce
         /// and return the INFO document describing the affected entities from an
         /// operation.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzAddRecordFlags"/></description>
         ///    </item>
@@ -48,7 +47,8 @@ namespace Senzing.Sdk
         ///      <description><see cref="SzFlagUsageGroup.SzRedoFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
+        /// </para>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzModifySet)]
         SzWithInfo = (1L << 62),
 
@@ -56,689 +56,1097 @@ namespace Senzing.Sdk
         /// The bitwise flag for export functionality to indicate "resolved"
         /// relationships (i.e.: entities with multiple records) should be
         /// included in the export.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzExportSet)]
         SzExportIncludeMultiRecordEntities = (1L << 0),
 
         /// <summary>
         /// The bitwise flag for export functionality to indicate that
         /// "possibly same" relationships should be included in the export.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzExportSet)]
         SzExportIncludePossiblySame = (1L << 1),
 
         /// <summary>
         /// The bitwise flag for export functionality to indicate that
         /// "possibly related" relationships should be included in the export.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzExportSet)]
         SzExportIncludePossiblyRelated = (1L << 2),
 
         /// <summary>
         /// The bitwise flag for export functionality to indicate that
         /// "name only" relationships should be included in the export.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzExportSet)]
         SzExportIncludeNameOnly = (1L << 3),
 
         /// <summary>
         /// The bitwise flag for export functionality to indicate that we
         /// should include "disclosed" relationships.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzExportSet)]
         SzExportIncludeDisclosed = (1L << 4),
 
         /// <summary>
         /// The bitwise flag for export functionality to indicate that
         /// single-record entities should be included in the export.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzExportSet)]
         SzExportIncludeSingleRecordEntities = (1L << 5),
 
         /// <summary>
         /// The bitwise flag for including possibly-same relations for entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludePossiblySameRelations = (1L << 6),
 
         /// <summary>
         /// The bitwise flag for including possibly-related relations for entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludePossiblyRelatedRelations = (1L << 7),
 
         /// <summary>
         /// The bitwise flag for including name-only relations for entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludeNameOnlyRelations = (1L << 8),
 
         /// <summary>
         /// The bitwise flag for including disclosed relations for entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludeDisclosedRelations = (1L << 9),
 
         /// <summary>
         /// The bitwise flag for including all features for entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
         SzEntityIncludeAllFeatures = (1L << 10),
 
         /// <summary>
         /// The bitwise flag for including representative features for entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
         SzEntityIncludeRepresentativeFeatures = (1L << 11),
 
         /// <summary>
         /// The bitwise flag for including the name of the entity.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
         SzEntityIncludeEntityName = (1L << 12),
 
         /// <summary>
         /// The bitwise flag for including the record summary of the entity.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
         SzEntityIncludeRecordSummary = (1L << 13),
 
         /// <summary>
         /// The bitwise flag for including the record types of the entity or record.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
         SzEntityIncludeRecordTypes = (1L << 28),
 
         /// <summary>
         /// The bitwise flag for including the basic record data for
         /// the entity.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
         SzEntityIncludeRecordData = (1L << 14),
 
         /// <summary>
         /// The bitwise flag for including the record matching info for
         /// the entity or record.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
         SzEntityIncludeRecordMatchingInfo = (1L << 15),
 
         /// <summary>
         /// The bitwise flag for including the record matching info for
         /// the entity or record.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntityRecordSet)]
         SzEntityIncludeRecordDates = (1L << 39),
 
         /// <summary>
         /// The bitwise flag for including the record json data for the
         /// entity or record.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordPreviewFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRecordPreviewSet)]
         SzEntityIncludeRecordJsonData = (1L << 16),
 
         /// <summary>
         /// The bitwise flag for including the record unmapped data for
         /// the entity or record.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordPreviewFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRecordPreviewSet)]
         SzEntityIncludeRecordUnmappedData = (1L << 31),
 
         /// <summary>
         /// The bitwise flag to include the features identifiers at the
         /// record level, referencing the entity features.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordPreviewFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRecordPreviewSet)]
         SzEntityIncludeRecordFeatures = (1L << 18),
 
         /// <summary>
         /// The bitwise flag for including full feature details at the
         /// record level of an entity response or in a record response.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordPreviewFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRecordPreviewSet)]
         SzEntityIncludeRecordFeatureDetails = (1L << 35),
 
         /// <summary>
         /// The bitwise flag for including full feature statistics at the
         /// record level of an entity response or in a record response.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordPreviewFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRecordPreviewSet)]
         SzEntityIncludeRecordFeatureStats = (1L << 36),
 
         /// <summary>
         /// The bitwise flag for including the name of the related entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludeRelatedEntityName = (1L << 19),
 
         /// <summary>
         /// The bitwise flag for including the record matching info of the related
         /// entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludeRelatedMatchingInfo = (1L << 20),
 
         /// <summary>
         /// The bitwise flag for including the record summary of the
         /// related entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludeRelatedRecordSummary = (1L << 21),
 
         /// <summary>
         /// The bitwise flag for including the record types of the
         /// related entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludeRelatedRecordTypes = (1L << 29),
 
         /// <summary>
         /// The bitwise flag for including the basic record data of the
         /// related entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRelationSet)]
         SzEntityIncludeRelatedRecordData = (1L << 22),
 
         /// <summary>
         /// The bitwise flag for including internal features in an entity
         /// response or record response.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordPreviewFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzRecordPreviewSet)]
         SzEntityIncludeInternalFeatures = (1L << 23),
 
         /// <summary>
         /// The bitwise flag for including feature statistics in entity responses.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntitySet)]
         SzEntityIncludeFeatureStats = (1L << 24),
 
         /// <summary>
         /// The bitwise flag for including match key details in addition to the 
         /// standard match key.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzHowFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzEntityHowSet)]
         SzIncludeMatchKeyDetails = (1L << 34),
 
@@ -747,206 +1155,86 @@ namespace Senzing.Sdk
         /// that avoided entities are not allowed under any
         /// circumstance -- even if they are the only means by which
         /// a path can be found between two entities.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzFindPathSet)]
         SzFindPathStrictAvoid = (1L << 25),
 
         /// <summary>
         /// The bitwise flag for find-path functionality to include
         /// matching info on entity paths.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzFindPathSet)]
         SzFindPathIncludeMatchingInfo = (1L << 30),
 
         /// <summary>
         /// The bitwise flag for find-network functionality to include
         /// matching info on entity paths of the network.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzFindNetworkSet)]
         SzFindNetworkIncludeMatchingInfo = (1L << 33),
 
         /// <summary>
         /// The bitwise flag for including feature scores.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzWhySearchFlags"/></description>
+        ///    </item>
+        ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzHowFlags"/></description>
         ///    </item>
         /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzHowWhySearchSet)]
         SzIncludeFeatureScores = (1L << 26),
 
         /// <summary>
         /// The bitwise flag for including statistics from search results.
-        /// </summary>
-        /// <remarks>
-        /// This flag belongs to the following usage groups:
-        /// <list>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
-        ///    </item>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzWhySearchFlags"/></description>
-        ///    </item>
-        /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
-        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzWhySearchSet)]
-        SzSearchIncludeStats = (1L << 27),
-
-        /// <summary>
-        /// The bitwise flag for search functionality to indicate that
-        /// "resolved" match level results should be included.
-        /// </summary>
-        /// <remarks>
-        /// This flag belongs to the following usage groups:
-        /// <list>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
-        ///    </item>
-        /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
-        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
-        SzSearchIncludeResolved = SzExportIncludeMultiRecordEntities,
-
-        /// <summary>
-        /// The bitwise flag for search functionality to indicate that
-        /// "possibly same" match level results should be included.
-        /// </summary>
-        /// <remarks>
-        /// This flag belongs to the following usage groups:
-        /// <list>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
-        ///    </item>
-        /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
-        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
-        SzSearchIncludePossiblySame = SzExportIncludePossiblySame,
-
-        /// <summary>
-        /// The bitwise flag for search functionality to indicate that
-        /// "possibly related" match level results should be included.
-        /// </summary>
-        /// <remarks>
-        /// This flag belongs to the following usage groups:
-        /// <list>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
-        ///    </item>
-        /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
-        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
-        SzSearchIncludePossiblyRelated = SzExportIncludePossiblyRelated,
-
-        /// <summary>
-        /// The bitwise flag for search functionality to indicate that
-        /// "name only" match level results should be included.
-        /// </summary>
-        /// <remarks>
-        /// This flag belongs to the following usage groups:
-        /// <list>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
-        ///    </item>
-        /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
-        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
-        SzSearchIncludeNameOnly = SzExportIncludeNameOnly,
-
-        /// <summary>
-        /// The bitwise flag for search functionality to indicate that
-        /// search results should not only include those entities that
-        /// satisfy resolution rule, but also those that present on the
-        /// candidate list but fail to satisfy a resolution rule.
-        /// </summary>
-        /// 
-        /// <remarks>
-        /// This flag belongs to the following usage groups:
-        /// <list>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
-        ///    </item>
-        /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
-        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
-        SzSearchIncludeAllCandidates = (1L << 32),
-
-        /// <summary>
-        /// The bitwise flag for search functionality to indicate that
-        /// the search response should include the basic feature
-        /// information for the search criteria features.
-        /// </summary>
-        /// 
-        /// <remarks>
-        /// This flag belongs to the following usage groups:
-        /// <list>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
-        ///    </item>
-        ///    <item>
-        ///      <description><see cref="SzFlagUsageGroup.SzWhySearchFlags"/></description>
-        ///    </item>
-        /// </list>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
-        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzWhySearchSet)]
-        SzSearchIncludeRequest = (1L << 37),
-
-        /// <summary>
-        /// The bitwise flag for search functionality to indicate that
-        /// the search response should include detailed feature 
-        /// information for search criteria features (including feature
-        /// stats and generic status).
-        /// </summary>
-        /// 
-        /// <remarks>
-        /// This flag has no effect unless
-        /// <see cref="SzSearchIncludeRequest"/> is also specified.
         /// <para>
         /// This flag belongs to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///    <item>
         ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
         ///    </item>
@@ -955,8 +1243,135 @@ namespace Senzing.Sdk
         ///    </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
+        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzWhySearchSet)]
+        SzSearchIncludeStats = (1L << 27),
+
+        /// <summary>
+        /// The bitwise flag for search functionality to indicate that
+        /// "resolved" match level results should be included.
+        /// <para>
+        /// This flag belongs to the following usage groups:
+        /// <list type="bullet">
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        /// </list>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
+        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
+        SzSearchIncludeResolved = SzExportIncludeMultiRecordEntities,
+
+        /// <summary>
+        /// The bitwise flag for search functionality to indicate that
+        /// "possibly same" match level results should be included.
+        /// <para>
+        /// This flag belongs to the following usage groups:
+        /// <list type="bullet">
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        /// </list>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
+        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
+        SzSearchIncludePossiblySame = SzExportIncludePossiblySame,
+
+        /// <summary>
+        /// The bitwise flag for search functionality to indicate that
+        /// "possibly related" match level results should be included.
+        /// <para>
+        /// This flag belongs to the following usage groups:
+        /// <list type="bullet">
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        /// </list>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
+        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
+        SzSearchIncludePossiblyRelated = SzExportIncludePossiblyRelated,
+
+        /// <summary>
+        /// The bitwise flag for search functionality to indicate that
+        /// "name only" match level results should be included.
+        /// <para>
+        /// This flag belongs to the following usage groups:
+        /// <list type="bullet">
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        /// </list>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
+        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
+        SzSearchIncludeNameOnly = SzExportIncludeNameOnly,
+
+        /// <summary>
+        /// The bitwise flag for search functionality to indicate that
+        /// search results should not only include those entities that
+        /// satisfy resolution rule, but also those that present on the
+        /// candidate list but fail to satisfy a resolution rule.
+        /// <para>
+        /// This flag belongs to the following usage groups:
+        /// <list type="bullet">
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        /// </list>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
+        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzSearchSet)]
+        SzSearchIncludeAllCandidates = (1L << 32),
+
+        /// <summary>
+        /// The bitwise flag for search functionality to indicate that
+        /// the search response should include the basic feature
+        /// information for the search criteria features.
+        /// <para>
+        /// This flag belongs to the following usage groups:
+        /// <list type="bullet">
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzWhySearchFlags"/></description>
+        ///    </item>
+        /// </list>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
+        [SzFlagUsageGroups(SzFlagUsageGroupSets.SzWhySearchSet)]
+        SzSearchIncludeRequest = (1L << 37),
+
+        /// <summary>
+        /// The bitwise flag for search functionality to indicate that
+        /// the search response should include detailed feature 
+        /// information for search criteria features (including feature
+        /// stats and generic status).
+        /// <para>
+        /// This flag has no effect unless
+        /// <see cref="SzSearchIncludeRequest"/> is also specified.
+        /// </para>
+        /// <para>
+        /// This flag belongs to the following usage groups:
+        /// <list type="bullet">
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
+        ///    </item>
+        ///    <item>
+        ///      <description><see cref="SzFlagUsageGroup.SzWhySearchFlags"/></description>
+        ///    </item>
+        /// </list>
+        /// </para>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         [SzFlagUsageGroups(SzFlagUsageGroupSets.SzWhySearchSet)]
         SzSearchIncludeRequestDetails = (1L << 38)
     }

--- a/Senzing.Sdk/SzFlagUsageGroup.cs
+++ b/Senzing.Sdk/SzFlagUsageGroup.cs
@@ -15,15 +15,17 @@ namespace Senzing.Sdk
         /// <summary>
         /// Flags in this usage group can be used for operations that add (load)
         /// records to the entity repository.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.AddRecord(string, string, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.AddRecord(string, string, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzWithInfo"/></description>
         ///   </item>
@@ -31,28 +33,30 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzAddRecordDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzAddRecordFlags = (1L << 0),
 
         /// <summary>
         /// Flags in this usage group can be used for operations that delete
         /// records from the entity repository.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.DeleteRecord(string, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.DeleteRecord(string, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzWithInfo"/></description>
         ///   </item>
@@ -60,28 +64,30 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzDeleteRecordDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzDeleteRecordFlags = (1L << 1),
 
         /// <summary>
         /// Flags in this usage group can be used for operations that reevaluate
         /// records in the entity repository.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.ReevaluateRecord(string, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.ReevaluateRecord(string, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzWithInfo"/></description>
         ///   </item>
@@ -89,28 +95,30 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzReevaluateRecordDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzReevaluateRecordFlags = (1L << 2),
 
         /// <summary>
         /// Flags in this usage group can be used for operations that reevaluate
         /// entities in the entity repository.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.ReevaluateEntity(long, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.ReevaluateEntity(long, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzWithInfo"/></description>
         ///   </item>
@@ -118,28 +126,30 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzReevaluateEntityDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzReevaluateEntityFlags = (1L << 3),
 
         /// <summary>
         /// Flags in this usage group can be used for operations that process 
         /// redo records in the entity repository.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.ProcessRedoRecord(string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.ProcessRedoRecord(string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzWithInfo"/></description>
         ///   </item>
@@ -147,28 +157,30 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRedoDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzRedoFlags = (1L << 4),
 
         /// <summary>
         /// Flags in this usage group can be used for operations that retrieve record
         /// data in order to control the level of detail of the returned record.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.GetRecord(string, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.GetRecord(string, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludeInternalFeatures"/></description>
         ///   </item>
@@ -194,28 +206,30 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzRecordFlags = (1L << 5),
 
         /// <summary>
         /// Flags in this usage group can be used for operations that retrieve record
         /// data in order to control the level of detail of the returned record.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.GetRecord(string, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.GetRecord(string, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludeInternalFeatures"/></description>
         ///   </item>
@@ -238,29 +252,31 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordPreviewDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzRecordPreviewFlags = (1L << 6),
 
         /// <summary>
         /// Flags in this usage group can be used for operations that retrieve
         /// entity data in order to control the level of detail of the returned
         /// entity.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.GetEntity(long, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.GetEntity(long, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -337,7 +353,7 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzEntityIncludeAllRelations"/></description>
         ///   </item>
@@ -352,7 +368,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -361,8 +377,8 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzEntityFlags = (1L << 7),
 
         /// <summary>
@@ -370,16 +386,20 @@ namespace Senzing.Sdk
         /// finding an entity path, what details to include for the entity 
         /// path and the level of detail for the entities on the path that
         /// are returned.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.FindPath(long, long, int, System.Collections.Generic.ISet{long}, System.Collections.Generic.ISet{string}, SzFlag?)"/></item>
-        ///   <item><see cref="SzEngine.FindPath(string, string, string, string, int, System.Collections.Generic.ISet{ValueTuple{string, string}}, System.Collections.Generic.ISet{string}, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.FindPath(long, long, int, System.Collections.Generic.ISet{long}, System.Collections.Generic.ISet{string}, SzFlag?)"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="SzEngine.FindPath(string, string, string, string, int, System.Collections.Generic.ISet{ValueTuple{string, string}}, System.Collections.Generic.ISet{string}, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -463,7 +483,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "find-path" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzFindPathDefaultFlags"/></description>
         ///   </item>
@@ -472,7 +492,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -490,8 +510,8 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzFindPathFlags = (1L << 8),
 
         /// <summary>
@@ -499,16 +519,20 @@ namespace Senzing.Sdk
         /// finding an entity network, what details to include for the entity 
         /// network and the level of detail for the entities in the network
         /// that are returned.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.FindNetwork(System.Collections.Generic.ISet{long}, int, int, int, SzFlag?)"/></item>
-        ///   <item><see cref="SzEngine.FindNetwork(System.Collections.Generic.ISet{ValueTuple{string, string}}, int, int, int, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.FindNetwork(System.Collections.Generic.ISet{long}, int, int, int, SzFlag?)"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="SzEngine.FindNetwork(System.Collections.Generic.ISet{ValueTuple{string, string}}, int, int, int, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -589,7 +613,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "find-path" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzFindNetworkDefaultFlags"/></description>
         ///   </item>
@@ -598,7 +622,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -616,21 +640,25 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzFindNetworkFlags = (1L << 9),
 
         /// <summary>
         /// Flags in this usage group can be used to control the methodology for
         /// finding an interesting entities and what details to include for the
         /// results of the operation.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.FindInterestingEntities(string, string, SzFlag?)"/></item>
-        ///   <item><see cref="SzEngine.FindInterestingEntities(long, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.FindInterestingEntities(string, string, SzFlag?)"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="SzEngine.FindInterestingEntities(long, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// Currently, there are no <see cref="SzFlag"/> instances included in this usage group.
         /// However, this is a placeholder for when such flags are defined in a future release.
@@ -638,14 +666,14 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "find-path" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzFindInterestingEntitiesDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzFindInterestingEntitiesFlags = (1L << 10),
 
         /// <summary>
@@ -653,16 +681,20 @@ namespace Senzing.Sdk
         /// entities to control how the entities are qualified for inclusion
         /// in the search results and the level of detail for the entities
         /// returned in the search results.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.SearchByAttributes(string, SzFlag?)"/></item>
-        ///   <item><see cref="SzEngine.SearchByAttributes(string, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.SearchByAttributes(string, SzFlag?)"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="SzEngine.SearchByAttributes(string, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -767,7 +799,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "search" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzSearchIncludeAllEntities"/></description>
         ///   </item>
@@ -791,7 +823,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -809,8 +841,8 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzSearchFlags = (1L << 11),
 
         /// <summary>
@@ -818,16 +850,20 @@ namespace Senzing.Sdk
         /// entities to control how the entities are qualified for inclusion
         /// in the export and the level of detail for the entities returned
         /// in the search results.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.ExportJsonEntityReport(SzFlag?)"/></item>
-        ///   <item><see cref="SzEngine.ExportCsvEntityReport(string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.ExportJsonEntityReport(SzFlag?)"/></description>
+        ///   </item>
+        ///   <item>
+        ///     <description><see cref="SzEngine.ExportCsvEntityReport(string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -919,7 +955,7 @@ namespace Senzing.Sdk
         /// </para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "export" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzExportIncludeAllEntities"/></description>
         ///   </item>
@@ -933,7 +969,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -951,8 +987,8 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzExportFlags = (1L << 12),
 
         /// <summary>
@@ -960,15 +996,17 @@ namespace Senzing.Sdk
         /// performing "why analysis", what details to include for the analysis
         /// and the level of detail for the entities in the network that are 
         /// returned.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.WhyRecordInEntity(string, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.WhyRecordInEntity(string, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -1049,7 +1087,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "why" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzWhyRecordInEntityDefaultFlags"/></description>
         ///   </item>
@@ -1058,7 +1096,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -1076,8 +1114,8 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzWhyRecordInEntityFlags = (1L << 13),
 
         /// <summary>
@@ -1085,15 +1123,17 @@ namespace Senzing.Sdk
         /// performing "why analysis", what details to include for the analysis
         /// and the level of detail for the entities in the network that are 
         /// returned.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.WhyRecords(string, string, string, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.WhyRecords(string, string, string, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -1174,7 +1214,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "why" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzWhyRecordsDefaultFlags"/></description>
         ///   </item>
@@ -1183,7 +1223,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -1201,8 +1241,8 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzWhyRecordsFlags = (1L << 14),
 
         /// <summary>
@@ -1210,15 +1250,17 @@ namespace Senzing.Sdk
         /// performing "why analysis", what details to include for the analysis
         /// and the level of detail for the entities in the network that are 
         /// returned.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.WhyEntities(long, long, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.WhyEntities(long, long, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -1299,7 +1341,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "why" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzWhyEntitiesDefaultFlags"/></description>
         ///   </item>
@@ -1308,7 +1350,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -1326,8 +1368,8 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzWhyEntitiesFlags = (1L << 15),
 
         /// <summary>
@@ -1335,15 +1377,17 @@ namespace Senzing.Sdk
         /// entities to control how the entities are qualified for inclusion
         /// in the search results and the level of detail for the entities
         /// returned in the search results.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.WhySearch(string, long, string, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.WhySearch(string, long, string, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -1433,7 +1477,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "search" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzWhySearchDefaultFlags"/></description>
         ///   </item>
@@ -1442,7 +1486,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -1460,8 +1504,8 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzWhySearchFlags = (1L << 16),
 
         /// <summary>
@@ -1469,19 +1513,17 @@ namespace Senzing.Sdk
         /// performing "how analysis", what details to include for the analysis
         /// and the level of detail for the entities in the network that are 
         /// returned.
-        /// Flags in this usage group can be used to control the methodology for
-        /// performing "why analysis", what details to include for the analysis
-        /// and the level of detail for the entities in the network that are 
-        /// returned.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.HowEntity(long, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.HowEntity(long, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzIncludeMatchKeyDetails"/></description>
         ///   </item>
@@ -1493,7 +1535,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that use this
         /// group and are defined for "how" operations are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzHowEntityDefaultFlags"/></description>
         ///   </item>
@@ -1502,7 +1544,7 @@ namespace Senzing.Sdk
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants that also 
         /// support this group for defining entity or record detail levels are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzRecordDefaultFlags"/></description>
         ///   </item>
@@ -1520,23 +1562,25 @@ namespace Senzing.Sdk
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzHowFlags = (1L << 17),
 
         /// <summary>
         /// Flags in this usage group can be used for operations that retrieve
         /// virtual entities in order to control the level of detail of the
         /// returned virtual entity.
-        /// </summary>
-        /// <remarks>
+        /// <para>
         /// Applicable methods include:
-        /// <list>
-        ///   <item><see cref="SzEngine.GetVirtualEntity(System.Collections.Generic.ISet{ValueTuple{string, string}}, SzFlag?)"/></item>
+        /// <list type="bullet">
+        ///   <item>
+        ///     <description><see cref="SzEngine.GetVirtualEntity(System.Collections.Generic.ISet{ValueTuple{string, string}}, SzFlag?)"/></description>
+        ///   </item>
         /// </list>
+        /// </para>
         /// <para>
         /// The <see cref="SzFlag"/> instances included in this usage group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlag.SzEntityIncludeAllFeatures"/></description>
         ///   </item>
@@ -1583,14 +1627,14 @@ namespace Senzing.Sdk
         /// </para>
         /// <para>
         /// The pre-defined <see cref="SzFlag"/> aggregate constants for this group are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlags.SzVirtualEntityDefaultFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
-        /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// </summary>
         SzVirtualEntityFlags = (1L << 18)
     }
 

--- a/Senzing.Sdk/SzFlags.cs
+++ b/Senzing.Sdk/SzFlags.cs
@@ -165,7 +165,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzAddRecordFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzAddRecordFlags"/>
         public const SzFlag SzAddRecordAllFlags = SzFlag.SzWithInfo;
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzDeleteRecordFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzDeleteRecordFlags"/>
         public const SzFlag SzDeleteRecordAllFlags = SzFlag.SzWithInfo;
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzReevaluateRecordFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzReevaluateRecordFlags"/>
         public const SzFlag SzReevaluateRecordAllFlags = SzFlag.SzWithInfo;
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzReevaluateEntityFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzReevaluateEntityFlags"/>
         public const SzFlag SzReevaluateEntityAllFlags = SzFlag.SzWithInfo;
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzDeleteRecordFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzDeleteRecordFlags"/>
         public const SzFlag SzRedoAllFlags = SzFlag.SzWithInfo;
 
         /// <summary>
@@ -209,8 +209,8 @@ namespace Senzing.Sdk
         /// constants belonging to the <see cref="SzFlagUsageGroup.SzRecordFlags"/>
         /// usage group.
         /// </summary>
-        ///
-        /// <seealso cref="SzFlagUsageGroup.SzRecordFlags"/>
+        /// 
+        /// See also: <seealso cref="SzFlagUsageGroup.SzRecordFlags"/>
         public const SzFlag SzRecordAllFlags
             = SzFlag.SzEntityIncludeInternalFeatures
                 | SzFlag.SzEntityIncludeRecordFeatures
@@ -226,7 +226,7 @@ namespace Senzing.Sdk
         /// <see cref="SzFlagUsageGroup.SzRecordPreviewFlags"/> usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzRecordPreviewFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzRecordPreviewFlags"/>
         public const SzFlag SzRecordPreviewAllFlags
             = SzFlag.SzEntityIncludeInternalFeatures
                 | SzFlag.SzEntityIncludeRecordFeatures
@@ -241,7 +241,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzEntityFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzEntityFlags"/>
         public const SzFlag SzEntityAllFlags
             = SzFlag.SzEntityIncludePossiblySameRelations
                 | SzFlag.SzEntityIncludePossiblyRelatedRelations
@@ -275,7 +275,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzFindPathFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzFindPathFlags"/>
         public const SzFlag SzFindPathAllFlags
             = SzEntityAllFlags
                 | SzFlag.SzFindPathStrictAvoid
@@ -287,7 +287,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzFindNetworkFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzFindNetworkFlags"/>
         public const SzFlag SzFindNetworkAllFlags
             = SzEntityAllFlags | SzFlag.SzFindNetworkIncludeMatchingInfo;
 
@@ -297,7 +297,7 @@ namespace Senzing.Sdk
         /// <see cref="SzFlagUsageGroup.SzFindInterestingEntitiesFlags"/> usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzFindInterestingEntitiesFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzFindInterestingEntitiesFlags"/>
         public const SzFlag SzFindInterestingEntitiesAllFlags
             = SzNoFlags;
 
@@ -307,7 +307,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzSearchFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzSearchFlags"/>
         public const SzFlag SzSearchAllFlags
             = SzEntityAllFlags
                 | SzFlag.SzIncludeMatchKeyDetails
@@ -327,7 +327,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzWhySearchFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzWhySearchFlags"/>
         public const SzFlag SzWhySearchAllFlags
             = SzEntityAllFlags
                 | SzFlag.SzIncludeFeatureScores
@@ -341,7 +341,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzExportFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzExportFlags"/>
         public const SzFlag SzExportAllFlags
             = SzEntityAllFlags
                 | SzFlag.SzExportIncludeMultiRecordEntities
@@ -357,7 +357,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/>
         public const SzFlag SzWhyRecordInEntityAllFlags
             = SzEntityAllFlags | SzFlag.SzIncludeFeatureScores;
 
@@ -367,7 +367,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/>
         public const SzFlag SzWhyRecordsAllFlags
             = SzEntityAllFlags | SzFlag.SzIncludeFeatureScores;
 
@@ -377,7 +377,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/>
         public const SzFlag SzWhyEntitiesAllFlags
             = SzEntityAllFlags | SzFlag.SzIncludeFeatureScores;
 
@@ -387,7 +387,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzHowFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzHowFlags"/>
         public const SzFlag SzHowAllFlags
             = SzFlag.SzIncludeMatchKeyDetails | SzFlag.SzIncludeFeatureScores;
 
@@ -397,7 +397,7 @@ namespace Senzing.Sdk
         /// usage group.
         /// </summary>
         ///
-        /// <seealso cref="SzFlagUsageGroup.SzVirtualEntityFlags"/>
+        /// See also: <seealso cref="SzFlagUsageGroup.SzVirtualEntityFlags"/>
         public const SzFlag SzVirtualEntityAllFlags
             = SzFlag.SzEntityIncludeAllFeatures
                   | SzFlag.SzEntityIncludeAllFeatures
@@ -422,7 +422,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzExportIncludeMultiRecordEntities"/></description>
         ///   </item>
@@ -432,14 +432,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzExportIncludeAllEntities
             = SzFlag.SzExportIncludeMultiRecordEntities
                 | SzFlag.SzExportIncludeSingleRecordEntities;
@@ -450,7 +450,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzExportIncludePossiblySame"/></description>
         ///   </item>
@@ -466,14 +466,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzExportIncludeAllHavingRelationships
             = SzFlag.SzExportIncludePossiblySame
                 | SzFlag.SzExportIncludePossiblyRelated
@@ -485,7 +485,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzEntityIncludePossiblySameRelations"/></description>
         ///   </item>
@@ -503,7 +503,7 @@ namespace Senzing.Sdk
         /// All the flags in this constant belong to the 
         /// <see cref="SzFlagUsageGroup.SzEntityFlags"/> usage group, and by extension 
         /// belong to the following usage groups which are super sets:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
         ///   </item>
@@ -531,7 +531,7 @@ namespace Senzing.Sdk
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzEntityIncludeAllRelations
             = SzFlag.SzEntityIncludePossiblySameRelations
                 | SzFlag.SzEntityIncludePossiblyRelatedRelations
@@ -545,7 +545,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzSearchIncludeResolved"/></description>
         ///   </item>
@@ -561,14 +561,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzSearchIncludeAllEntities
             = SzFlag.SzSearchIncludeResolved
                 | SzFlag.SzSearchIncludePossiblySame
@@ -581,7 +581,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzEntityIncludeRecordJsonData"/></description>
         ///   </item>
@@ -590,7 +590,7 @@ namespace Senzing.Sdk
         /// All the flags in this constant belong to the 
         /// <see cref="SzFlagUsageGroup.SzRecordFlags"/> usage group, and by extension 
         /// belong to the following usage groups which are super sets:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzRecordFlags"/></description>
         ///   </item>
@@ -621,7 +621,7 @@ namespace Senzing.Sdk
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzRecordDefaultFlags
             = (SzFlag.SzEntityIncludeRecordJsonData);
 
@@ -634,7 +634,7 @@ namespace Senzing.Sdk
         /// other aggregate constants.
         /// <para>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzEntityIncludeRepresentativeFeatures"/></description>
         ///   </item>
@@ -656,7 +656,7 @@ namespace Senzing.Sdk
         /// All the flags in this constant belong to the 
         /// <see cref="SzFlagUsageGroup.SzEntityFlags"/> usage group, and by extension 
         /// belong to the following usage groups which are super sets:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
         ///   </item>
@@ -684,7 +684,7 @@ namespace Senzing.Sdk
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzEntityCoreFlags
             = SzFlag.SzEntityIncludeRepresentativeFeatures
                 | SzFlag.SzEntityIncludeEntityName
@@ -698,7 +698,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description>All flags from <see cref="SzEntityCoreFlags"/></description>
         ///   </item>
@@ -722,7 +722,7 @@ namespace Senzing.Sdk
         /// All the flags in this constant belong to the 
         /// <see cref="SzFlagUsageGroup.SzEntityFlags"/> usage group, and by extension 
         /// belong to the following usage groups which are super sets:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
         ///   </item>
@@ -750,7 +750,7 @@ namespace Senzing.Sdk
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzEntityDefaultFlags
             = SzEntityCoreFlags
                 | SzEntityIncludeAllRelations
@@ -764,7 +764,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description>All flags from <see cref="SzEntityIncludeAllRelations"/></description>
         ///   </item>
@@ -779,7 +779,7 @@ namespace Senzing.Sdk
         /// All the flags in this constant belong to the 
         /// <see cref="SzFlagUsageGroup.SzEntityFlags"/> usage group, and by extension 
         /// belong to the following usage groups which are super sets:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzEntityFlags"/></description>
         ///   </item>
@@ -807,7 +807,7 @@ namespace Senzing.Sdk
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzEntityBriefDefaultFlags
             = SzEntityIncludeAllRelations
                 | SzFlag.SzEntityIncludeRecordMatchingInfo
@@ -819,7 +819,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description>All flags from <see cref="SzExportIncludeAllEntities"/></description>
         ///   </item>
@@ -829,14 +829,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzExportFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzExportDefaultFlags
             = (SzExportIncludeAllEntities | SzEntityDefaultFlags);
 
@@ -846,7 +846,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzFindPathIncludeMatchingInfo"/></description>
         ///   </item>
@@ -859,14 +859,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzFindPathFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzFindPathDefaultFlags
             = (SzFlag.SzFindPathIncludeMatchingInfo
                 | SzFlag.SzEntityIncludeEntityName
@@ -878,7 +878,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzFindNetworkIncludeMatchingInfo"/></description>
         ///   </item>
@@ -891,14 +891,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzFindNetworkFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzFindNetworkDefaultFlags
             = (SzFlag.SzFindNetworkIncludeMatchingInfo
                 | SzFlag.SzEntityIncludeEntityName
@@ -910,21 +910,21 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzIncludeFeatureScores"/></description>
         ///   </item>
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzWhyEntitiesFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzWhyEntitiesDefaultFlags = SzFlag.SzIncludeFeatureScores;
 
         /// <summary>
@@ -933,21 +933,21 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzIncludeFeatureScores"/></description>
         ///   </item>
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzWhyRecordsFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzWhyRecordsDefaultFlags = SzFlag.SzIncludeFeatureScores;
 
         /// <summary>
@@ -956,21 +956,21 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzIncludeFeatureScores"/></description>
         ///   </item>
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzWhyRecordInEntityFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzWhyRecordInEntityDefaultFlags
             = SzFlag.SzIncludeFeatureScores;
 
@@ -980,21 +980,21 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzIncludeFeatureScores"/></description>
         ///   </item>
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzHowFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzHowEntityDefaultFlags
             = (SzFlag.SzIncludeFeatureScores);
 
@@ -1004,21 +1004,21 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description>All flags from <see cref="SzEntityCoreFlags"/></description>
         ///   </item>
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzVirtualEntityFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzVirtualEntityDefaultFlags = SzEntityCoreFlags;
 
         /// <summary>
@@ -1027,7 +1027,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description>All flags from <see cref="SzSearchIncludeAllEntities"/></description>
         ///   </item>
@@ -1049,14 +1049,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzSearchByAttributesAll
             = SzSearchIncludeAllEntities
                 | SzFlag.SzSearchIncludeStats
@@ -1071,7 +1071,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzSearchIncludeResolved"/></description>
         ///   </item>
@@ -1096,14 +1096,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzSearchByAttributesStrong
             = SzFlag.SzSearchIncludeResolved
                 | SzFlag.SzSearchIncludePossiblySame
@@ -1120,7 +1120,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description>All flags from <see cref="SzSearchIncludeAllEntities"/></description>
         ///   </item>
@@ -1130,14 +1130,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzSearchByAttributesMinimalAll
             = SzSearchIncludeAllEntities | SzFlag.SzSearchIncludeStats;
 
@@ -1149,7 +1149,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzSearchIncludeResolved"/></description>
         ///   </item>
@@ -1162,14 +1162,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzSearchByAttributesMinimalStrong
             = SzFlag.SzSearchIncludeResolved
             | SzFlag.SzSearchIncludePossiblySame
@@ -1181,21 +1181,21 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description>All flags from <see cref="SzSearchByAttributesAll"/></description>
         ///   </item>
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzSearchFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzSearchByAttributesDefaultFlags = SzSearchByAttributesAll;
 
         /// <summary>
@@ -1204,7 +1204,7 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzIncludeFeatureScores"/></description>
         ///   </item>
@@ -1217,14 +1217,14 @@ namespace Senzing.Sdk
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzWhySearchFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzWhySearchDefaultFlags
             = SzIncludeFeatureScores
             | SzSearchIncludeRequestDetails
@@ -1238,14 +1238,14 @@ namespace Senzing.Sdk
         /// Currently, this is equivalent to <see cref="SzFlags.SzNoFlags"/>.
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzAddRecordFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzAddRecordDefaultFlags = SzNoFlags;
 
         /// <summary>
@@ -1256,14 +1256,14 @@ namespace Senzing.Sdk
         /// Currently, this is equivalent to <see cref="SzFlags.SzNoFlags"/>.
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzDeleteRecordFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzDeleteRecordDefaultFlags = SzNoFlags;
 
         /// <summary>
@@ -1273,21 +1273,21 @@ namespace Senzing.Sdk
         /// </summary>
         /// <remarks>
         /// The included <see cref="SzFlag"/> values are:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///      <description><see cref="SzFlag.SzEntityIncludeRecordFeatureDetails"/></description>
         ///   </item>
         /// </list>
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzRecordPreviewFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzRecordPreviewDefaultFlags
             = SzEntityIncludeRecordFeatureDetails;
 
@@ -1299,14 +1299,14 @@ namespace Senzing.Sdk
         /// Currently, this is equivalent to <see cref="SzFlags.SzNoFlags"/>.
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzReevaluateRecordFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzReevaluateRecordDefaultFlags = SzNoFlags;
 
         /// <summary>
@@ -1317,14 +1317,14 @@ namespace Senzing.Sdk
         /// Currently, this is equivalent to <see cref="SzFlags.SzNoFlags"/>.
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzReevaluateEntityFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzReevaluateEntityDefaultFlags = SzReevaluateRecordDefaultFlags;
 
         /// <summary>
@@ -1335,14 +1335,14 @@ namespace Senzing.Sdk
         /// Currently, this is equivalent to <see cref="SzFlags.SzNoFlags"/>.
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzFindInterestingEntitiesFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzFindInterestingEntitiesDefaultFlags = SzNoFlags;
 
         /// <summary>
@@ -1353,14 +1353,14 @@ namespace Senzing.Sdk
         /// Currently, this is equivalent to <see cref="SzFlags.SzNoFlags"/>.
         /// <para>
         /// All the flags in this constant belong to the following usage groups:
-        /// <list>
+        /// <list type="bullet">
         ///   <item>
         ///     <description><see cref="SzFlagUsageGroup.SzRedoFlags"/></description>
         ///   </item>
         /// </list>
         /// </para>
         /// </remarks>
-        /// <seealso href="https://docs.senzing.com/flags/index.html"/>
+        /// See also: <seealso href="https://docs.senzing.com/flags/index.html"/>
         public const SzFlag SzRedoDefaultFlags = SzNoFlags;
 
         /// <summary>

--- a/Senzing.Sdk/core/SzCoreEnvironment.cs
+++ b/Senzing.Sdk/core/SzCoreEnvironment.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 
+using static Senzing.Sdk.Core.SzCoreUtilities;
+
 namespace Senzing.Sdk.Core
 {
     /// <summary>
@@ -60,37 +62,6 @@ namespace Senzing.Sdk.Core
         /// Internal object for class-wide synchronized locking.
         /// </summary>
         private static readonly Object ClassMonitor = new Object();
-
-        /// <summary>
-        /// The <see cref="System.Collections.ObjectModel.ReadOnlyDictionary{TKey, TValue}"/>
-        /// of integer error code keys to <c>Type</c> values representing the exception class
-        /// associated with the respective error code.
-        /// </summary>
-        /// 
-        /// <remarks>
-        /// The dictionary does not store entries that map to <see cref="SzException"/>
-        /// since that is the default for any error code not otherwise mapped.
-        /// </remarks>
-        internal static readonly ReadOnlyDictionary<long, Type> ExceptionMap;
-
-        /// <summary>
-        /// The class initializer.
-        /// </summary>
-        static SzCoreEnvironment()
-        {
-            IDictionary<long, Type> map = new Dictionary<long, Type>();
-            IDictionary<long, Type> result = new Dictionary<long, Type>();
-            SzExceptionMapper.RegisterExceptions(map);
-            Type baseType = typeof(SzException);
-            foreach (KeyValuePair<long, Type> mapping in map)
-            {
-                if (!baseType.Equals(mapping.Value))
-                {
-                    result.Add(mapping.Key, mapping.Value);
-                }
-            }
-            ExceptionMap = new ReadOnlyDictionary<long, Type>(result);
-        }
 
         /// <summary>
         /// Enumerates the possible states for an instance of <c>SzCoreEnvironment</c>.
@@ -543,47 +514,6 @@ namespace Senzing.Sdk.Core
 
             // create the appropriate exception
             throw CreateSzException(errorCode, message);
-        }
-
-
-        /// <summary>
-        /// Creates the appropriate <see cref="SzException"/> instance for the
-        /// specified error code. 
-        /// </summary>
-        /// 
-        /// <remarks>
-        /// If there is a failure in creating the <see cref="SzException"/> 
-        /// instance, then a generic <see cref="SzException"/> is created with 
-        /// the specified parameters and "caused by" exception describing the
-        /// failure.  
-        /// </remarks>
-        /// 
-        /// <param name="errorCode">
-        /// The error code to use to determine the specific type for the
-        /// <see cref="SzException"/> instance.
-        /// </param>
-        /// 
-        /// <param name="message">
-        /// The error message to associate with the exception.
-        /// </param>
-        /// 
-        /// <returns></returns>
-        public static SzException CreateSzException(long errorCode, string message)
-        {
-            // get the exception class
-            Type exceptionType = ExceptionMap.ContainsKey(errorCode)
-                ? ExceptionMap[errorCode] : typeof(SzException);
-
-            try
-            {
-                return (SzException)Activator.CreateInstance(exceptionType,
-                                                             errorCode,
-                                                             message);
-            }
-            catch (Exception e)
-            {
-                return new SzException(errorCode, message, e);
-            }
         }
 
         /// <summary>

--- a/Senzing.Sdk/core/SzCoreUtilities.cs
+++ b/Senzing.Sdk/core/SzCoreUtilities.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Senzing.Sdk.Core
+{
+    /// <summary>
+    /// Provides utility functions that are useful when implementing
+    /// the Senzing SDK interfaces from the <c>Senzing.Sdk</c> namespace.
+    /// This is functionality leveraged by the "core" implementation
+    /// that is made visible to aid in other implementations.
+    /// </summary>
+    /// 
+    /// <remarks>
+    /// None of the functionality provided here is required to use the 
+    /// <see cref="Senzing.Sdk.Core.SzCoreEnvironment"/> class, but may
+    /// be useful if creating an alternate implementation of
+    /// <see cref="Senzing.Sdk.SzEnvironment"/>.
+    /// </remarks>
+    public static class SzCoreUtilities
+    {
+        /// <summary>
+        /// The <b>unmodifiable</b> collection of default data sources.
+        /// </summary>
+        private static readonly ReadOnlyCollection<string> DefaultSources
+            = new ReadOnlyCollection<string>(
+                new List<string>(new[] { "TEST", "SEARCH" }));
+
+        /// <summary>
+        /// The <see cref="System.Collections.ObjectModel.ReadOnlyDictionary{TKey, TValue}"/>
+        /// of integer error code keys to <c>Type</c> values representing the exception class
+        /// associated with the respective error code.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// The dictionary does not store entries that map to <see cref="SzException"/>
+        /// since that is the default for any error code not otherwise mapped.
+        /// </remarks>
+        internal static readonly ReadOnlyDictionary<long, Type> ExceptionMap;
+
+        /// <summary>
+        /// The class initializer.
+        /// </summary>
+        static SzCoreUtilities()
+        {
+            IDictionary<long, Type> map = new Dictionary<long, Type>();
+            IDictionary<long, Type> result = new Dictionary<long, Type>();
+            SzExceptionMapper.RegisterExceptions(map);
+            Type baseType = typeof(SzException);
+            foreach (KeyValuePair<long, Type> mapping in map)
+            {
+                if (!baseType.Equals(mapping.Value))
+                {
+                    result.Add(mapping.Key, mapping.Value);
+                }
+            }
+            ExceptionMap = new ReadOnlyDictionary<long, Type>(result);
+        }
+
+        /// <summary>
+        /// Creates the appropriate <see cref="SzException"/> instance for the
+        /// specified error code. 
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// If there is a failure in creating the <see cref="SzException"/> 
+        /// instance, then a generic <see cref="SzException"/> is created with 
+        /// the specified parameters and "caused by" exception describing the
+        /// failure.  
+        /// </remarks>
+        /// 
+        /// <param name="errorCode">
+        /// The error code to use to determine the specific type for the
+        /// <see cref="SzException"/> instance.
+        /// </param>
+        /// 
+        /// <param name="message">
+        /// The error message to associate with the exception.
+        /// </param>
+        /// 
+        /// <returns></returns>
+        public static SzException CreateSzException(long errorCode, string message)
+        {
+            // get the exception class
+            Type exceptionType = ExceptionMap.ContainsKey(errorCode)
+                ? ExceptionMap[errorCode] : typeof(SzException);
+
+            try
+            {
+                return (SzException)Activator.CreateInstance(exceptionType,
+                                                             errorCode,
+                                                             message);
+            }
+            catch (Exception e)
+            {
+                return new SzException(errorCode, message, e);
+            }
+        }
+
+        /// <summary>
+        /// Produce an auto-generated configuration comment for the
+        /// configuration manager registry.  This is useful when implementing
+        /// the <see cref="Senzing.Sdk.SzConfigManager.RegisterConfig(string)"/>
+        /// function.
+        /// </summary>
+        /// 
+        /// <param name="configDefinition">
+        /// The <c>string</c> configuration definition.
+        /// </param>
+        ///
+        /// <returns>
+        /// The auto-generated comment, which may be empty-string
+        /// if an auto-generated comment could not otherwise be inferred.
+        /// </returns>
+        public static string CreateConfigComment(string configDefinition)
+        {
+            int index = configDefinition.IndexOf("\"CFG_DSRC\"");
+            if (index < 0)
+            {
+                return "";
+            }
+            char[] charArray = configDefinition.ToCharArray();
+
+            // advance past any whitespace
+            index = EatWhiteSpace(charArray, index + "\"CFG_DSRC\"".Length);
+
+            // check for the colon
+            if (index >= charArray.Length || charArray[index++] != ':')
+            {
+                return "";
+            }
+
+            // advance past any whitespace
+            index = EatWhiteSpace(charArray, index);
+
+            // check for the open bracket
+            if (index >= charArray.Length || charArray[index++] != '[')
+            {
+                return "";
+            }
+
+            // find the end index
+            int endIndex = configDefinition.IndexOf("]", index);
+            if (endIndex < 0)
+            {
+                return "";
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("Data Sources: ");
+            string prefix = "";
+            int dataSourceCount = 0;
+            ISet<string> defaultSources = new SortedSet<string>();
+            while (index > 0 && index < endIndex)
+            {
+                index = configDefinition.IndexOf("\"DSRC_CODE\"", index);
+                if (index < 0 || index >= endIndex)
+                {
+                    continue;
+                }
+                index = EatWhiteSpace(charArray, index + "\"DSRC_CODE\"".Length);
+
+                // check for the colon
+                if (index >= endIndex || charArray[index++] != ':')
+                {
+                    return "";
+                }
+
+                index = EatWhiteSpace(charArray, index);
+
+                // check for the quote
+                if (index >= endIndex || charArray[index++] != '"')
+                {
+                    return "";
+                }
+                int start = index;
+
+                // find the ending quote
+                while (index < endIndex && charArray[index] != '"')
+                {
+                    index++;
+                }
+                if (index >= endIndex)
+                {
+                    return "";
+                }
+
+                // get the data source code
+                string dataSource = configDefinition.Substring(start, (index - start));
+                if (DefaultSources.Contains(dataSource))
+                {
+                    defaultSources.Add(dataSource);
+                    continue;
+                }
+                sb.Append(prefix);
+                sb.Append(dataSource);
+                dataSourceCount++;
+                prefix = ", ";
+            }
+
+            // check if only the default data sources
+            if (dataSourceCount == 0 && defaultSources.Count == 0)
+            {
+                sb.Append("[ NONE ]");
+            }
+            else if (dataSourceCount == 0
+                    && defaultSources.Count == DefaultSources.Count)
+            {
+                sb.Append("[ ONLY DEFAULT ]");
+
+            }
+            else if (dataSourceCount == 0)
+            {
+
+                sb.Append("[ SOME DEFAULT (");
+                prefix = "";
+                foreach (String source in defaultSources)
+                {
+                    sb.Append(prefix);
+                    sb.Append(source);
+                    prefix = ", ";
+                }
+                sb.Append(") ]");
+            }
+
+            // return the constructed string
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Finds the index of the first non-whitespace character after the
+        /// specified index from the specified character array.
+        /// </summary>
+        ///
+        /// <param name="charArray">The character array.</param>
+        /// <param name="fromIndex">The starting index.</param>
+        ///
+        /// <returns>
+        /// The index of the first non-whitespace character or the length of
+        /// the character array if no non-whitespace character is found.
+        /// </returns>
+        internal static int EatWhiteSpace(char[] charArray, int fromIndex)
+        {
+            int index = fromIndex;
+
+            // advance past any whitespace
+            while (index < charArray.Length && Char.IsWhiteSpace(charArray[index]))
+            {
+                index++;
+            }
+
+            // return the index
+            return index;
+        }
+    }
+}


### PR DESCRIPTION
- Refactored reusable "core" functions to `SzCoreUtilities` class.
- Fixes bulleted list documentation to work around `docfx` bug in default templates
- Modifies `enum` documentation (`SzFlag` and `SzFlagUsageGroup`) to work around `docfx` bug in default template for enum documentation.

Resolves Issue #127 
